### PR TITLE
Added -dALLOWTRANSPARENCY option to ps2pdf to allow transparent objects drawing using sketch

### DIFF
--- a/common_resources/fig/sketch/compile_sketch.sh
+++ b/common_resources/fig/sketch/compile_sketch.sh
@@ -32,7 +32,7 @@ else
   dvips -Ppdf -G0 "$NAME.dvi"
   rm "$NAME.dvi"
 
-  ps2pdf -dNOSAFER "$NAME.ps"
+  ps2pdf -dNOSAFER -dALLOWPSTRANSPARENCY "$NAME.ps"
   pdfcrop "$NAME.pdf" "$NAME.pdf"
 
   rm "$NAME.ps"


### PR DESCRIPTION
I discovered that the default setting `opacity=...` option for objects in `sketch` does not work. The solution is simply adding the `-dALLOWPSTRANSPARENCY` option to ps2pdf. However, I'm not sure if it doesn't break anything